### PR TITLE
nvim > plugins > cmp: fix buffer keyword length

### DIFF
--- a/.config/nvim/lua/config/plugins/cmp.lua
+++ b/.config/nvim/lua/config/plugins/cmp.lua
@@ -25,7 +25,7 @@ cmp.setup({
         { name = "nvim_lsp" },
         { name = "luasnip" },
         { name = "path" },
-        { name = "buffer", keyword_lenght = 5 },
+        { name = "buffer", keyword_length = 5 },
         { name = "calc" },
     }),
     formatting = {


### PR DESCRIPTION
For the plugin [hrsh7th/cmp-buffer](https://github.com/hrsh7th/cmp-buffer), the option `keyword_length` is mispelled to `keyword_lenght`.

https://github.com/UserIsntAvailable/dotfiles/blob/72981249e86425031c2e805dd5b368d62eb21cf1/.config/nvim/lua/config/plugins/cmp.lua#L28